### PR TITLE
Update .vimrc settings

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -17,5 +17,24 @@ Plugin 'nvie/vim-flake8'
 " All of your Plugins must be added before the following line
 call vundle#end()            " required
 filetype plugin indent on    " required
-						    
+
+" enable syntax highlighting
 syntax enable
+
+" Show line numbers
+set number
+
+" set tabs to have 4 spaces
+set ts=4
+
+" indent when moving to next line while coding
+set noautoindent
+
+" show matching part of the pair of brackets
+set showmatch
+
+" enable all python syntax highlighting features
+let python_highlight_all = 1
+
+" Set scripts to be executable from the shell
+au BufWritePost * if getline(1) =~ "^#!" | if getline(1) =~ "/bin/" | silent !chmod +x <afile> | endif | endif


### PR DESCRIPTION
added more options to the .vimrc file in the vim directory.

Autoindenting makes formatting more difficult for writing code in
Python. Set noautoindent to unset this.
